### PR TITLE
Remember preview scroll position in URL and when navigating browser history

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,8 +15,7 @@ module.exports = function( grunt ) {
 			},
 			all: [
 				'Gruntfile.js',
-				'js/*.js',
-				'!js/*.min.js'
+				'*.js'
 			]
 		},
 

--- a/customizer-browser-history.js
+++ b/customizer-browser-history.js
@@ -7,6 +7,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 	'use strict';
 
 	var component = {
+		defaultQueryParamValues: {},
 		defaultPreviewedDevice: null,
 		expandedPanel: new api.Value(),
 		expandedSection: new api.Value(),
@@ -24,10 +25,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		var urlParser, queryParams, queryString;
 		urlParser = document.createElement( 'a' );
 		urlParser.href = url;
-		queryParams = {
-			url: api.settings.url.preview,
-			device: component.defaultPreviewedDevice
-		};
+		queryParams = {};
 		queryString = urlParser.search.substr( 1 );
 		if ( queryString ) {
 			_.each( queryString.split( '&' ), function( pair ) {
@@ -88,7 +86,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			'autofocus[section]': component.expandedSection,
 			'autofocus[control]': component.expandedControl,
 			device: api.previewedDevice,
-			'scroll': component.previewScrollPosition
+			scroll: component.previewScrollPosition
 		};
 
 		// Preserve extra vars.
@@ -98,9 +96,10 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			}
 		} );
 
+		// Collect new query params, omitting any that are the same as the defaults.
 		_.each( values, function( valueObj, key ) {
 			var value = valueObj.get();
-			if ( value ) {
+			if ( null !== value && value !== component.defaultQueryParamValues[ key ] ) {
 				newQueryParams[ key ] = value;
 			}
 		} );
@@ -209,6 +208,15 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			component.previewScrollPosition.set( currentQueryParams.scroll );
 			api.previewer.scroll = component.previewScrollPosition.get();
 		}
+
+		component.defaultQueryParamValues = {
+			device: component.defaultPreviewedDevice,
+			scroll: 0,
+			url: api.settings.url.home,
+			'autofocus[panel]': '',
+			'autofocus[section]': '',
+			'autofocus[control]': ''
+		};
 
 		$( window ).on( 'popstate', component.onPopState );
 

--- a/customizer-browser-history.js
+++ b/customizer-browser-history.js
@@ -30,8 +30,8 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		if ( queryString ) {
 			_.each( queryString.split( '&' ), function( pair ) {
 				var parts = pair.split( '=', 2 );
-				if ( parts[0] && parts[1] ) {
-					queryParams[ decodeURIComponent( parts[0] ) ] = decodeURIComponent( parts[1] );
+				if ( parts[0] ) {
+					queryParams[ decodeURIComponent( parts[0] ) ] = _.isUndefined( parts[1] ) ? null : decodeURIComponent( parts[1] );
 				}
 			} );
 		}
@@ -108,7 +108,10 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			urlParser = document.createElement( 'a' );
 			urlParser.href = location.href;
 			urlParser.search = _.map( newQueryParams, function( value, key ) {
-				var pair = encodeURIComponent( key ) + '=' + encodeURIComponent( value );
+				var pair = encodeURIComponent( key );
+				if ( null !== value ) {
+					pair += '=' + encodeURIComponent( value );
+				}
 				pair = pair.replace( /%5B/g, '[' ).replace( /%5D/g, ']' );
 				return pair;
 			} ).join( '&' );

--- a/customizer-browser-history.js
+++ b/customizer-browser-history.js
@@ -26,7 +26,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		urlParser.href = url;
 		queryParams = {
 			url: api.settings.url.preview,
-			customize_previewed_device: component.defaultPreviewedDevice
+			device: component.defaultPreviewedDevice
 		};
 		queryString = urlParser.search.substr( 1 );
 		if ( queryString ) {
@@ -87,7 +87,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			'autofocus[panel]': component.expandedPanel,
 			'autofocus[section]': component.expandedSection,
 			'autofocus[control]': component.expandedControl,
-			customize_previewed_device: api.previewedDevice,
+			device: api.previewedDevice,
 			'scroll': component.previewScrollPosition
 		};
 

--- a/customizer-browser-history.js
+++ b/customizer-browser-history.js
@@ -1,7 +1,7 @@
 /* global wp */
 /* exported CustomizerBrowserHistory */
-/* eslint no-magic-numbers: ["error", { "ignore": [0,1,2] }] */
-/* eslint complexity: ["error", 6] */
+/* eslint no-magic-numbers: ["error", { "ignore": [0,1,2,10] }] */
+/* eslint complexity: ["error", 8] */
 
 var CustomizerBrowserHistory = (function( api, $ ) {
 	'use strict';
@@ -10,7 +10,42 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		defaultPreviewedDevice: null,
 		expandedPanel: new api.Value(),
 		expandedSection: new api.Value(),
-		expandedControl: new api.Value()
+		expandedControl: new api.Value(),
+		previewScrollPosition: new api.Value( 0 )
+	};
+
+	/**
+	 * Get current query params.
+	 *
+	 * @param {string} url URL.
+	 * @returns {object} Query params.
+	 */
+	component.getQueryParams = function getQueryParams( url ) {
+		var urlParser, queryParams, queryString;
+		urlParser = document.createElement( 'a' );
+		urlParser.href = url;
+		queryParams = {
+			url: api.settings.url.preview,
+			customize_previewed_device: component.defaultPreviewedDevice
+		};
+		queryString = urlParser.search.substr( 1 );
+		if ( queryString ) {
+			_.each( queryString.split( '&' ), function( pair ) {
+				var parts = pair.split( '=', 2 );
+				if ( parts[0] && parts[1] ) {
+					queryParams[ decodeURIComponent( parts[0] ) ] = decodeURIComponent( parts[1] );
+				}
+			} );
+		}
+
+		if ( ! _.isUndefined( queryParams.preview_scroll_position ) ) {
+			queryParams.preview_scroll_position = parseInt( queryParams.preview_scroll_position, 10 );
+			if ( isNaN( queryParams.preview_scroll_position ) ) {
+				delete queryParams.preview_scroll_position;
+			}
+		}
+
+		return queryParams;
 	};
 
 	/**
@@ -19,7 +54,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 	 * @returns {void}
 	 */
 	component.updateState = _.debounce( function updateState() {
-		var expandedPanel = '', expandedSection = '', expandedControl = '', values, urlParser, oldQueryParams, newQueryParams, queryString;
+		var expandedPanel = '', expandedSection = '', expandedControl = '', values, urlParser, oldQueryParams, newQueryParams;
 
 		api.panel.each( function( panel ) {
 			if ( panel.active() && panel.expanded() ) {
@@ -42,30 +77,17 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		component.expandedPanel.set( expandedPanel );
 		component.expandedSection.set( expandedSection );
 		component.expandedControl.set( expandedControl );
+		component.previewScrollPosition.set( api.previewer.scroll );
 
-		urlParser = document.createElement( 'a' );
-		urlParser.href = location.href;
-		oldQueryParams = {
-			url: api.settings.url.preview,
-			customize_previewed_device: component.defaultPreviewedDevice
-		};
-		queryString = urlParser.search.substr( 1 );
-		if ( queryString ) {
-			_.each( queryString.split( '&' ), function( pair ) {
-				var parts = pair.split( '=', 2 );
-				if ( parts[0] && parts[1] ) {
-					oldQueryParams[ decodeURIComponent( parts[0] ) ] = decodeURIComponent( parts[1] );
-				}
-			} );
-		}
-
+		oldQueryParams = component.getQueryParams( location.href );
 		newQueryParams = {};
 		values = {
 			url: api.previewer.previewUrl,
 			'autofocus[panel]': component.expandedPanel,
 			'autofocus[section]': component.expandedSection,
 			'autofocus[control]': component.expandedControl,
-			customize_previewed_device: api.previewedDevice
+			customize_previewed_device: api.previewedDevice,
+			'preview_scroll_position': component.previewScrollPosition
 		};
 
 		// Preserve extra vars.
@@ -83,6 +105,8 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		} );
 
 		if ( ! _.isEqual( newQueryParams, oldQueryParams ) ) {
+			urlParser = document.createElement( 'a' );
+			urlParser.href = location.href;
 			urlParser.search = _.map( newQueryParams, function( value, key ) {
 				var pair = encodeURIComponent( key ) + '=' + encodeURIComponent( value );
 				pair = pair.replace( /%5B/g, '[' ).replace( /%5D/g, ']' );
@@ -105,6 +129,15 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 	 */
 	component.onPopState = function onPopState( event ) {
 		var url = null;
+
+		// Preserve the old scroll position.
+		if ( event.originalEvent.state && event.originalEvent.state.preview_scroll_position ) {
+			api.previewer.scroll = event.originalEvent.state.preview_scroll_position;
+		} else {
+			api.previewer.scroll = 0;
+		}
+
+		// Update the url.
 		if ( event.originalEvent.state && event.originalEvent.state.url ) {
 			url = event.originalEvent.state.url;
 		} else {
@@ -161,13 +194,20 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 	};
 
 	api.bind( 'ready', function onCustomizeReady() {
+		var currentQueryParams;
 
 		// Short-circuit if not supported.
 		if ( ! history.replaceState || ! history.pushState ) {
 			return;
 		}
 
+		currentQueryParams = component.getQueryParams( location.href );
+
 		component.defaultPreviewedDevice = component.findDefaultPreviewedDevice();
+		if ( currentQueryParams.preview_scroll_position ) {
+			component.previewScrollPosition.set( parseInt( currentQueryParams.preview_scroll_position, 10 ) || 0 );
+			api.previewer.scroll = component.previewScrollPosition.get();
+		}
 
 		$( window ).on( 'popstate', component.onPopState );
 
@@ -189,6 +229,8 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 
 		api.previewedDevice.bind( component.updateState );
 		api.previewer.previewUrl.bind( component.updateState );
+		api.previewer.bind( 'scroll', component.updateState );
+		component.previewScrollPosition.bind( component.updateState );
 	} );
 
 	return component;

--- a/customizer-browser-history.js
+++ b/customizer-browser-history.js
@@ -38,10 +38,11 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			} );
 		}
 
-		if ( ! _.isUndefined( queryParams.preview_scroll_position ) ) {
-			queryParams.preview_scroll_position = parseInt( queryParams.preview_scroll_position, 10 );
-			if ( isNaN( queryParams.preview_scroll_position ) ) {
-				delete queryParams.preview_scroll_position;
+		// Cast scroll to integer.
+		if ( ! _.isUndefined( queryParams.scroll ) ) {
+			queryParams.scroll = parseInt( queryParams.scroll, 10 );
+			if ( isNaN( queryParams.scroll ) ) {
+				delete queryParams.scroll;
 			}
 		}
 
@@ -87,7 +88,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 			'autofocus[section]': component.expandedSection,
 			'autofocus[control]': component.expandedControl,
 			customize_previewed_device: api.previewedDevice,
-			'preview_scroll_position': component.previewScrollPosition
+			'scroll': component.previewScrollPosition
 		};
 
 		// Preserve extra vars.
@@ -131,8 +132,8 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		var url = null;
 
 		// Preserve the old scroll position.
-		if ( event.originalEvent.state && event.originalEvent.state.preview_scroll_position ) {
-			api.previewer.scroll = event.originalEvent.state.preview_scroll_position;
+		if ( event.originalEvent.state && event.originalEvent.state.scroll ) {
+			api.previewer.scroll = event.originalEvent.state.scroll;
 		} else {
 			api.previewer.scroll = 0;
 		}
@@ -204,8 +205,8 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 		currentQueryParams = component.getQueryParams( location.href );
 
 		component.defaultPreviewedDevice = component.findDefaultPreviewedDevice();
-		if ( currentQueryParams.preview_scroll_position ) {
-			component.previewScrollPosition.set( parseInt( currentQueryParams.preview_scroll_position, 10 ) || 0 );
+		if ( currentQueryParams.scroll ) {
+			component.previewScrollPosition.set( currentQueryParams.scroll );
 			api.previewer.scroll = component.previewScrollPosition.get();
 		}
 

--- a/customizer-browser-history.php
+++ b/customizer-browser-history.php
@@ -41,17 +41,17 @@ function customizer_browser_history_enqueue_scripts() {
 add_action( 'customize_controls_enqueue_scripts', 'customizer_browser_history_enqueue_scripts' );
 
 /**
- * Filter the available devices to change default based on customize_previewed_device query param.
+ * Filter the available devices to change default based on device query param.
  *
  * @see WP_Customize_Manager::get_previewable_devices()
  * @param array $devices List of devices with labels and default setting.
  * @return array Devices.
  */
 function customizer_browser_history_filter_default_previewable_devices( $devices ) {
-	if ( ! isset( $_GET['customize_previewed_device'] ) ) {
+	if ( ! isset( $_GET['device'] ) ) {
 		return $devices;
 	}
-	$device_name = wp_unslash( $_GET['customize_previewed_device'] );
+	$device_name = wp_unslash( $_GET['device'] );
 	if ( ! isset( $devices[ $device_name ] ) ) {
 		return $devices;
 	}

--- a/customizer-browser-history.php
+++ b/customizer-browser-history.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Customizer Browser History
- * Version: 0.3.0
+ * Version: 0.4.0
  * Description: Keep Customizer URL updated with current previewed URL as url param and current expanded panel/section/control as autofocus param. This allows for bookmarking and also the ability to reload and return go the same view. This is a feature plugin for <a href="https://core.trac.wordpress.org/ticket/28536">#28536</a> and it works best with the <a href="https://github.com/xwp/wp-customize-snapshots">Customize Snapshots</a> plugin.
  * Plugin URI: https://github.com/xwp/wp-customizer-browser-history
  * Author: Weston Ruter

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customizer-browser-history",
   "title": "Customizer Browser History",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ And while these changes to the `autofocus` params are being made in the browser'
 Note that the `url` param will be URL-encoded. So a typical Customizer URL would get updated to look like:
 
 <pre>
-http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&customize_previewed_device=mobile
+http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&device=mobile
 </pre>
 
 **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customizer-browser-history). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customizer-browser-history/issues) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customizer-browser-history).**

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Sync browser URL in Customizer with current preview URL and focused panels, sect
 **Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize)  
 **Requires at least:** 4.5  
 **Tested up to:** 4.6  
-**Stable tag:** 0.3  
+**Stable tag:** 0.4.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customizer-browser-history.svg?branch=master)](https://travis-ci.org/xwp/wp-customizer-browser-history) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) 
@@ -17,23 +17,35 @@ Sync browser URL in Customizer with current preview URL and focused panels, sect
 
 *This is a feature plugin intended to implement [#28536](https://core.trac.wordpress.org/ticket/28536): Add browser history and deep linking for navigation in Customizer preview*
 
-This plugin keeps the Customizer URL in the browser updated with current previewed URL as the `url` query param and current expanded panel/section/control as `autofocus` params. This allows for bookmarking and also the ability to reload and return go the same view (which is great for developers), including which device you are previewing (desktop, tablet, or mobile). Not only will the URL be kept in sync with the current customizer UI, but new browser history entries will be added as you navigate around the site in the preview (via `history.pushState()`), allowing you to use the back/forward buttons as you would normally when browsing the site outside the customizer. This plugin complements well the <a href="https://github.com/xwp/wp-customize-snapshots">Customize Snapshots</a> plugin which allows you to save your Customizer state in a shapshot/changeset with an associated UUID that also gets added to the browser URL in the Customizer.
+This plugin keeps the Customizer URL in the browser updated with current previewed URL as the `url` query param and current expanded panel/section/control as `autofocus` params. This allows for bookmarking and also the ability to reload and return go the same view (which is great for developers), including which device you are previewing (desktop, tablet, or mobile). Not only will the URL be kept in sync with the current customizer UI, but new browser history entries will be added as you navigate around the site in the preview (via `history.pushState()`), allowing you to use the back/forward buttons as you would normally when browsing the site outside the customizer. The scroll position for each previewed URL is tracked as well, so that when you navigate back/forward the scroll position will be restored, just as happens when browsing the site outside the customizer preview. Restoring the scroll position also works when reloading the customizer, as the position is persisted in a `scroll` query parameter: again, this is extremely useful during development.
+
+This plugin complements well the <a href="https://github.com/xwp/wp-customize-snapshots">Customize Snapshots</a> plugin which allows you to save your Customizer state in a shapshot/changeset with an associated UUID that also gets added to the browser URL in the Customizer.
 
 For example, if you load the Customizer and then click the “Site Identity” section, the URL will be replaced to add `autofocus[section]=title_tagline`.
 
-If you navigate into the nav menus panel, open a menu section, and then expand a nav menu item control, then the URL will have these autofocus params added: `autofocus[panel]=nav_menus&autofocus[section]=nav_menu[87]&autofocus[control]=nav_menu_item[5123]`.
+If you navigate into the nav menus panel, open a menu section, and then expand a nav menu item control, then the URL will have these `autofocus` params added:
+
+<pre>
+autofocus[panel]=nav_menus&autofocus[section]=nav_menu[87]&autofocus[control]=nav_menu_item[5123]
+</pre>
 
 And while these changes to the `autofocus` params are being made in the browser's URL as the Customizer UI is interacted with, if you navigate to another page in the preview the `url` parameter will also be replaced to reflect the new preview URL.
 
 Note that the `url` param will be URL-encoded. So a typical Customizer URL would get updated to look like:
 
 <pre>
-http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&device=mobile
+http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&device=mobile&scroll=200
 </pre>
 
 **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customizer-browser-history). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customizer-browser-history/issues) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customizer-browser-history).**
 
 ## Changelog ##
+
+### 0.4.0 ###
+* Added persistence of `scroll` position when navigating back/forward in the preview and when reloading the customizer.
+* Renamed the `customize_previewed_device` query param to just `device`.
+* Improved the building of the URL query params to omit any params that are the same as the defaults, so `device=desktop` and `scroll=0` should not be shown, nor should a `url` that points to the home URL.
+* Fixed dropping of value-less query params, e.g. `customize.php?debug`
 
 ### 0.3.0 ###
 * Add back/forward browser history for navigation in the Customizer preview. See [#2](https://github.com/xwp/wp-customizer-browser-history/issues/2), PR [#8](https://github.com/xwp/wp-customizer-browser-history/pull/8).

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ And while these changes to the `autofocus` params are being made in the browser'
 Note that the `url` param will be URL-encoded. So a typical Customizer URL would get updated to look like:
 
 <pre>
-http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&customize_previewed_device=mobile
+http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&device=mobile
 </pre>
 
 **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customizer-browser-history). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customizer-browser-history/issues) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customizer-browser-history).**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      xwp, westonruter
 Tags:              customizer, customize
 Requires at least: 4.5
 Tested up to:      4.6
-Stable tag:        0.3
+Stable tag:        0.4.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,23 +13,36 @@ Sync browser URL in Customizer with current preview URL and focused panels, sect
 
 *This is a feature plugin intended to implement [#28536](https://core.trac.wordpress.org/ticket/28536): Add browser history and deep linking for navigation in Customizer preview*
 
-This plugin keeps the Customizer URL in the browser updated with current previewed URL as the `url` query param and current expanded panel/section/control as `autofocus` params. This allows for bookmarking and also the ability to reload and return go the same view (which is great for developers), including which device you are previewing (desktop, tablet, or mobile). Not only will the URL be kept in sync with the current customizer UI, but new browser history entries will be added as you navigate around the site in the preview (via `history.pushState()`), allowing you to use the back/forward buttons as you would normally when browsing the site outside the customizer. This plugin complements well the <a href="https://github.com/xwp/wp-customize-snapshots">Customize Snapshots</a> plugin which allows you to save your Customizer state in a shapshot/changeset with an associated UUID that also gets added to the browser URL in the Customizer.
+This plugin keeps the Customizer URL in the browser updated with current previewed URL as the `url` query param and current expanded panel/section/control as `autofocus` params. This allows for bookmarking and also the ability to reload and return go the same view (which is great for developers), including which device you are previewing (desktop, tablet, or mobile). Not only will the URL be kept in sync with the current customizer UI, but new browser history entries will be added as you navigate around the site in the preview (via `history.pushState()`), allowing you to use the back/forward buttons as you would normally when browsing the site outside the customizer. The scroll position for each previewed URL is tracked as well, so that when you navigate back/forward the scroll position will be restored, just as happens when browsing the site outside the customizer preview. Restoring the scroll position also works when reloading the customizer, as the position is persisted in a `scroll` query parameter: again, this is extremely useful during development.
+
+This plugin complements well the <a href="https://github.com/xwp/wp-customize-snapshots">Customize Snapshots</a> plugin which allows you to save your Customizer state in a shapshot/changeset with an associated UUID that also gets added to the browser URL in the Customizer.
 
 For example, if you load the Customizer and then click the “Site Identity” section, the URL will be replaced to add `autofocus[section]=title_tagline`.
 
-If you navigate into the nav menus panel, open a menu section, and then expand a nav menu item control, then the URL will have these autofocus params added: `autofocus[panel]=nav_menus&autofocus[section]=nav_menu[87]&autofocus[control]=nav_menu_item[5123]`.
+If you navigate into the nav menus panel, open a menu section, and then expand a nav menu item control, then the URL will have these `autofocus` params added:
+
+<pre>
+autofocus[panel]=nav_menus&autofocus[section]=nav_menu[87]&autofocus[control]=nav_menu_item[5123]
+</pre>
 
 And while these changes to the `autofocus` params are being made in the browser's URL as the Customizer UI is interacted with, if you navigate to another page in the preview the `url` parameter will also be replaced to reflect the new preview URL.
 
 Note that the `url` param will be URL-encoded. So a typical Customizer URL would get updated to look like:
 
 <pre>
-http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&device=mobile
+http://example.com/wp-admin/customize.php?url=http%3A%2F%2Fexample.com%2Fsample-page%2F&autofocus[panel]=widgets&autofocus[section]=sidebar-widgets-sidebar-1&autofocus[control]=widget_text[10]&device=mobile&scroll=200
 </pre>
 
 **Development of this plugin is done [on GitHub](https://github.com/xwp/wp-customizer-browser-history). Pull requests welcome. Please see [issues](https://github.com/xwp/wp-customizer-browser-history/issues) reported there before going to the [plugin forum](https://wordpress.org/support/plugin/customizer-browser-history).**
 
 == Changelog ==
+
+= 0.4.0 =
+
+* Added persistence of `scroll` position when navigating back/forward in the preview and when reloading the customizer.
+* Renamed the `customize_previewed_device` query param to just `device`.
+* Improved the building of the URL query params to omit any params that are the same as the defaults, so `device=desktop` and `scroll=0` should not be shown, nor should a `url` that points to the home URL.
+* Fixed dropping of value-less query params, e.g. `customize.php?debug`
 
 = 0.3.0 =
 


### PR DESCRIPTION
A key feature of the browser is that when you reload a page, it will return you to the same scroll position as the page before you reloaded. Likewise, when you navigate back and forward in the browser history, the scroll position is remembered and restored as you navigate. This PR adds these capabilities to navigation in the Customizer preview.
