### PR TITLE
Prevent dropping url param when loading customizer

### DIFF
--- a/customizer-browser-history.js
+++ b/customizer-browser-history.js
@@ -266,7 +266,7 @@ var CustomizerBrowserHistory = (function( api, $ ) {
 				return defaultPreviewedDevice;
 			} )(),
 			'scroll': 0,
-			'url': api.settings.url.preview,
+			'url': api.settings.url.home,
 			'autofocus[panel]': '',
 			'autofocus[section]': '',
 			'autofocus[control]': ''


### PR DESCRIPTION
Let `home` be the default `url` param only, so that if the customizer is loaded with another initial URL it is not stripped as soon as the customizer is loaded.